### PR TITLE
Fix id type for category creation

### DIFF
--- a/intelbridge/zscaler/zscaler.py
+++ b/intelbridge/zscaler/zscaler.py
@@ -68,7 +68,7 @@ def create_catagory(token):
                'User-Agent' :'Zscaler-FalconX-Intel-Bridge-v2',
                'cookie': "JSESSIONID=" + str(token)}
     payload = {
-            "id": 0,
+            "id": "ANY",
             "configuredName": zs_url_category,
             "customCategory": "true",
             "superCategory": "USER_DEFINED",


### PR DESCRIPTION
Fix #34 

Zscaler API requires id to be of type string for category creation