### PR TITLE
Proactively refresh JSESSIONID before the 5-minute TTL expires

### DIFF
--- a/intelbridge/intelbridge.py
+++ b/intelbridge/intelbridge.py
@@ -52,14 +52,14 @@ class IntelBridge():
 
     def prepare(self, token, indicators):
         """Handles transforming indicators object into a Zscaler API ready model
-        token - Falcon API Auth token
+        token - Zscaler API Auth token
         indicators - List containing indicators pulled from Falcon API
-        returns: Indicator list formatted for Zscaler API ingestion
+        returns: (ingestable indicators, amount rejected, current Zscaler token)
         """
         prepared, amount_rejected_crwd = prepare_indicators(indicators)
-        ingestable, amount_rejected_zs = look_up_indicators(prepared, token)
+        ingestable, amount_rejected_zs, token = look_up_indicators(prepared, token)
         amount_rejected = amount_rejected_zs + amount_rejected_crwd
-        return ingestable, amount_rejected
+        return ingestable, amount_rejected, token
     
     def update(self, token, content, category, ingestable, deleted):
         """Handles updating the URL Category content
@@ -76,10 +76,10 @@ class IntelBridge():
                         [!!!] You are still protected during this phase;
                         indicator refresh won't take effect until new indicators are pushed
                         and changes are activated!""")
-            push_indicators(token, category, content, True)
+            _, token = push_indicators(token, category, content, True)
         # push new content
         logging.info(f"[Zscaler API] Pushing new indicators")
-        push_indicators(token, category, ingestable, False)
+        _, token = push_indicators(token, category, ingestable, False)
         # activate
         save_changes(token)
         return
@@ -102,7 +102,7 @@ class IntelBridge():
         content = category['content']
         start = int(time.time())
         indicators = self.pull(falcon, deleted)
-        ingestable, amount_rejected = self.prepare(zs_token, indicators)
+        ingestable, amount_rejected, zs_token = self.prepare(zs_token, indicators)
         # write_data(ingestable, deleted)
         self.update(zs_token, content, category_name, ingestable, deleted)
         end = int(time.time())

--- a/intelbridge/zscaler/zscaler.py
+++ b/intelbridge/zscaler/zscaler.py
@@ -21,6 +21,26 @@ zs_url_category = "CrowdStrike"
 log_config = config['LOG']
 data_log = int(log_config['log_indicators'])
 
+# Zscaler expires JSESSIONID after 5 minutes. Refresh at 4 to leave a safety margin
+# for in-flight requests and clock skew. Authentication is cheap: /authenticatedSession
+# POST is rate-limited to 2/sec and 1000/hr, so a multi-hour run can comfortably
+# re-auth dozens of times.
+ZS_SESSION_TTL = 240
+
+def _refresh_if_stale(token, headers, last_auth):
+    """Proactively re-auths when the JSESSIONID is approaching expiry.
+    token - current Zscaler JSESSIONID
+    headers - request headers dict; cookie is mutated in place
+    last_auth - epoch seconds when token was last issued
+    returns: (token, last_auth) - refreshed if stale, unchanged otherwise
+    """
+    if time.time() - last_auth > ZS_SESSION_TTL:
+        logging.info("[Zscaler API] Proactive JSESSIONID refresh (TTL threshold reached)")
+        token = zs_auth()
+        headers["cookie"] = "JSESSIONID=" + str(token)
+        last_auth = time.time()
+    return token, last_auth
+
 def refresh_token():
     """Refreshes Zscaler API Auth token
     returns: Zscaler API Auth token
@@ -139,6 +159,7 @@ def look_up_indicators(indicators, token):
     headers = {'content-type': "application/json",
                'cache-control': "no-cache",
                'cookie': "JSESSIONID=" + str(token)}
+    last_auth = time.time()
     chunks = split_indicators(indicators)
     amount_rejected = 0
     print(f"{'='*20}Zscaler API URL Lookup{'='*20}")
@@ -146,6 +167,7 @@ def look_up_indicators(indicators, token):
     for chunk in chunks:
         success  = False
         while not success:
+            token, last_auth = _refresh_if_stale(token, headers, last_auth)
             response = requests.post(url=url, headers=headers, data=json.dumps(chunk))
             if response.status_code == 429:
                 r = int(response.headers._store['retry-after'][1])
@@ -160,11 +182,13 @@ def look_up_indicators(indicators, token):
                 logging.info(f"[Zscaler API] 401 Token Expired: Renewing auth and retrying.")
                 token = zs_auth()
                 headers["cookie"] = "JSESSIONID=" + str(token)
+                last_auth = time.time()
                 continue
             if response.status_code == 412:
                 logging.info(f"[Zscaler API] 412 Unknown error: Renewing auth and retrying.")
                 token = zs_auth()
                 headers["cookie"] = "JSESSIONID=" + str(token)
+                last_auth = time.time()
                 continue
             if response.status_code == 400:
                 logging.info(f"[Zscaler API] 400 Bad Request: One or more indicators in this chunk are incompatible with the URL look-up API. Skipping this chunk.")
@@ -189,7 +213,7 @@ def look_up_indicators(indicators, token):
             progress = increment(progress, len(chunk))
             time.sleep(60)
     print(f"{'='*29}DONE{'='*29}")
-    return ingestable, amount_rejected
+    return ingestable, amount_rejected, token
 
 def push_indicators(token, category, indicators, deleted):
     """Pushes new indicators to the Zscaler API
@@ -209,20 +233,22 @@ def push_indicators(token, category, indicators, deleted):
     print(f"{'='*22 if deleted else '='*22}"
           f"{'Removing Old' if deleted else 'Posting New'}* URL's"
           f"{'='*21 if deleted else '='*22}")
-    results = put_chunks(indicators, url, headers, progress)
+    results, token = put_chunks(indicators, url, headers, progress, token)
     print(f"{'='*29}DONE{'='*29}")
     if data_log == 1:
         write_data(indicators, deleted)
-    return results
+    return results, token
 
-def put_chunks(indicators, url, headers, progress):
+def put_chunks(indicators, url, headers, progress, token):
     """Helper function for push_indicators that makes requests and tracks progress
     indicators - list of indicators
     url - Zscaler API URL
     headers - headers for HTTP request
     progress - progress object
-    returns: results of push
+    token - Zscaler API Auth token (refreshed in-place on TTL or 401)
+    returns: (results of push, current token)
     """
+    last_auth = time.time()
     results = []
     indicators = indicators['urls']
     partitions = math.ceil(len(indicators)/5000)
@@ -235,6 +261,7 @@ def put_chunks(indicators, url, headers, progress):
         #         progress[1] = progress[1] + 1
         #         continue
         while not success:
+            token, last_auth = _refresh_if_stale(token, headers, last_auth)
             payload = {"customCategory": "true",
                     "superCategory": "USER_DEFINED",
                     "urls": chunk,
@@ -255,6 +282,7 @@ def put_chunks(indicators, url, headers, progress):
                 logging.info(f"[Zscaler API] 401 Token Expired: Renewing auth and retrying.")
                 token = zs_auth()
                 headers["cookie"] = "JSESSIONID=" + str(token)
+                last_auth = time.time()
                 continue
             try:
                 response.raise_for_status()
@@ -271,14 +299,18 @@ def put_chunks(indicators, url, headers, progress):
             result = response.json()
             time.sleep(1)
     results.append(result)
-    return results
+    return results, token
 
 def save_changes(token):
     """Posts to Zscaler API to activate changes made in current etl_loop
-    token - Zscaler API Auth token
+    token - Zscaler API Auth token (may be stale after a long push)
     returns: HTTP results
     """
     logging.info(f"[Zscaler API] Activating changes")
+    # The preceding push phase can run for hours on large indicator sets. Re-auth
+    # here so the GET /status, POST /status/activate, and DELETE /authenticatedSession
+    # sequence always runs within a fresh 5-minute session window.
+    token = zs_auth()
     status_url = f"{zs_hostname}/api/v1/status"
     save_url = f"{zs_hostname}/api/v1/status/activate"
     headers = {'content-type': "application/json",


### PR DESCRIPTION
## Problem

Zscaler now expires `/authenticatedSession` JSESSIONIDs after 5 minutes (the TTL used to be much longer). The script's current refresh strategy is purely reactive — `look_up_indicators()` and `put_chunks()` re-auth only after a request returns 401, and the refreshed token is mutated into the local `headers` dict but **never returned to the caller**. So:

1. `etl_loop()` keeps holding the original `zs_token` that `etl_loop` was given.
2. `save_changes()` is invoked with that (possibly stale) token and has **no 401 retry of its own** — its `GET /status`, `POST /status/activate`, and `DELETE /authenticatedSession` calls fail outright when the session expires during the preceding push phase.

This is the most likely root cause of the recurring `[Zscaler API] Activate Changes error` / 401 reports — see the wall-clock math below.

## Wall-clock math on a realistic load

On a ~275,000-indicator run (operationally normal at our org), the verified [ZIA legacy API rate limits](https://help.zscaler.com/legacy-apis/api-rate-limit-summary) put a hard floor on runtime:

| Phase | Calls | Limit | Min runtime |
|---|---|---|---|
| `POST /urlLookup` (100 URLs/call) | 2,750 | 1/sec **and** 400/hr | ~6h 53m |
| `PUT /urlCategories/{id}` (5,000/chunk × remove + add) | ~110 | 1/sec and 400/hr | ~16 min |
| `POST /status/activate` | 1 | 10/min and 40/hr | trivial |

**Total: ~7 hours minimum**, during which the 5-minute JSESSIONID turns over ~85 times. Reactive-only refresh works *eventually* for the lookup/push loops (each chunk costs one 401 retry against the 400/hr ceiling), but `save_changes()` is a near-deterministic failure point.

`/authenticatedSession POST` is rate-limited to **2/sec and 1000/hr**, so even re-authing every 4 minutes over a 7-hour run consumes ~105 sessions — well under the cap. Aggressive re-auth is safe.

## Fix (minimal-diff, no new dependencies)

### `intelbridge/zscaler/zscaler.py`

- Add `ZS_SESSION_TTL = 240` constant and a small `_refresh_if_stale(token, headers, last_auth)` helper that re-auths when the cookie is older than 4 minutes.
- `look_up_indicators()` and `put_chunks()`: initialize `last_auth = time.time()` after building headers; call `_refresh_if_stale` at the top of every request attempt (initial **and** retry), so refresh happens *before* a request goes out, not after it fails. Also update `last_auth` in the existing 401/412 branches so reactive and proactive refresh share state.
- `push_indicators()` and `put_chunks()` now **return the live token** so the caller's variable doesn't drift stale.
- `put_chunks()` signature gains a `token` parameter (it already mutated `headers["cookie"]` locally; now it can hand the refreshed token back up properly).
- `save_changes()` calls `zs_auth()` at entry. The activate sequence is three quick requests in <1 sec wall-clock; a fresh login guarantees they fit inside any 5-minute window, and the final `zs_logout()` cleanly closes that fresh session.

### `intelbridge/intelbridge.py`

- `prepare()` returns the live token alongside `(ingestable, amount_rejected)`.
- `update()` captures the refreshed token from each `push_indicators()` call before calling `save_changes()`.
- `etl_loop()` reassigns `zs_token` from `prepare()`'s return value.

### Diff size

```
 intelbridge/intelbridge.py     | 14 ++++++-------
 intelbridge/zscaler/zscaler.py | 46 +++++++++++++++++++++++++++++++++++-------
 2 files changed, 46 insertions(+), 14 deletions(-)
```

## Behavior on short runs

The helper is a no-op when `last_auth` is fresh, so runs that finish inside 4 minutes see zero extra HTTP traffic and zero behavior change. The fix only kicks in when it actually matters.

## What this does *not* change

- No change to the 60-second sleep between `urlLookup` chunks. That's a throughput discussion separate from the auth fix.
- No change to chunk sizes, rate-limit handling, or 429 backoff.
- No new dependencies, no new modules, no wrapper classes.

## Possibly related open issues

The 401 / activate-failure / "Integration not Working" symptoms in #41, #38, and #37 are consistent with the 5-minute TTL blowing mid-run. This PR may resolve them — happy to coordinate with reporters if useful.

## Testing status

- Both files pass `python -m py_compile`.
- Diff is logic-reviewed; refresh fires before every request attempt (initial and retry), and the token plumbing back through `prepare()`/`update()`/`etl_loop()` is straightforward.
- **Not yet validated against a live ZIA tenant.** We plan to run the patched script against our production ZIA tenant on the next scheduled cycle and will report observed log lines (`Proactive JSESSIONID refresh (TTL threshold reached)`) and end-to-end success here.
- I've reached out to the maintainers offline to coordinate review.